### PR TITLE
Lesson 3

### DIFF
--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,4 +1,9 @@
 class Place < ActiveRecord::Base
+  # Added slug to URL
+  def to_param
+    "#{id}-#{slug.parameterize}"
+  end
+
   attr_accessible :address, :city, :country, :slug, :lat, :lon, :name, :rating
 
   # write your model validations here

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -35,4 +35,9 @@ describe Place do
       it { expect(subject.description(:long)).to eql("Amazing Place: Somewhere 1, Köln (Lat: 50.94 | Long: 6.96)") }
     end
   end
+
+  describe '#to_param' do
+    subject { Place.create(name: "Delicious Place", address: "Some address 123", city: "Foo", country: "Foo", slug: "delicious-foobar-place", lat: 5.9123, lon: 49.123, rating: 5) }
+    it { expect(subject.to_param).to eql("#{subject.id}-#{subject.slug}")}
+  end
 end


### PR DESCRIPTION
By default, Rails uses the model's id in the URL. 

`.../places/1`

What if you want to use the name of the model instead?

for example: `.../places/1-delicious-foobar-place` 
