### PR TITLE
to_param when we have no slug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,4 @@ end
 
 gem 'jquery-rails'
 gem 'coveralls', require: false
-# gem 'psych'
+gem 'psych'

--- a/Gemfile
+++ b/Gemfile
@@ -29,4 +29,4 @@ end
 
 gem 'jquery-rails'
 gem 'coveralls', require: false
-gem 'psych'
+# gem 'psych'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
+    psych (2.0.2)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -178,6 +179,7 @@ DEPENDENCIES
   guard-rspec
   jquery-rails
   pg
+  psych
   rails (= 3.2.14)
   rails_12factor
   rspec-pride

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,6 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.4)
-    psych (2.0.1)
     rack (1.4.5)
     rack-cache (1.2)
       rack (>= 0.4)
@@ -179,7 +178,6 @@ DEPENDENCIES
   guard-rspec
   jquery-rails
   pg
-  psych
   rails (= 3.2.14)
   rails_12factor
   rspec-pride

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -1,8 +1,4 @@
 class Place < ActiveRecord::Base
-  # Added slug to URL
-  def to_param
-    "#{id}-#{slug.parameterize}"
-  end
 
   attr_accessible :address, :city, :country, :slug, :lat, :lon, :name, :rating
 
@@ -25,5 +21,19 @@ class Place < ActiveRecord::Base
       "#{name}: #{address}, #{city} (Lat: #{lat.round(2)} | Long: #{lon.round(2)})"
     end
   end
-end
 
+
+  # Added slug to URL
+  def to_param
+    "#{id}-#{slug.parameterize}"
+  rescue
+    update_attribute(:slug, build_slug)
+    "#{id}-#{build_slug}"
+  end
+
+  def build_slug
+    "#{name.parameterize}-#{city.parameterize}"
+  rescue
+    "place"
+  end
+end

--- a/app/views/places/show.html.erb
+++ b/app/views/places/show.html.erb
@@ -21,11 +21,6 @@
 </p>
 
 <p>
-  <b>Language:</b>
-  <%= @place.language %>
-</p>
-
-<p>
   <b>Lat:</b>
   <%= @place.lat %>
 </p>

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -46,6 +46,7 @@ describe Place do
 
       describe 'rescue and update slug' do
         it { expect{ subject.to_param }.to change { subject.slug }.from(nil).to("delicious-place-foo") }
+        it { expect(subject.to_param).to eql("#{subject.id}-delicious-place-foo") }
       end
     end
   end

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -37,7 +37,17 @@ describe Place do
   end
 
   describe '#to_param' do
-    subject { Place.create(name: "Delicious Place", address: "Some address 123", city: "Foo", country: "Foo", slug: "delicious-foobar-place", lat: 5.9123, lon: 49.123, rating: 5) }
+    subject { Place.create(name: "Delicious Place", address: "Some address 123", city: "Foo", country: "Bar", slug: "delicious-place-foo", lat: 5.9123, lon: 49.123, rating: 5) }
     it { expect(subject.to_param).to eql("#{subject.id}-#{subject.slug}")}
+
+    context 'when we have no slug' do
+      before { subject.update_attribute(:slug, nil) }
+      it { expect { subject.to_param }.to_not raise_error }
+
+      describe 'rescue and update slug' do
+        it { expect{ subject.to_param }.to change { subject.slug }.from(nil).to("delicious-place-foo") }
+      end
+    end
   end
+
 end


### PR DESCRIPTION
Remember when we needed to ask in the places view if `slug.nil?`, to avoid the scary exception? 
Today we learn how to deal with this more gracefully (so it's not needed in the view), and more important "repair" the place data directly in case of an error. 

some resources, in case you get stuck: 
- http://www.mikeperham.com/2012/03/03/the-perils-of-rescue-exception/
- http://www.rubyinside.com/21-ruby-tricks-902.html

Have fun! 
